### PR TITLE
Increase max CPU limit to 7500m in my-mule-app.yaml

### DIFF
--- a/my-mule-app.yaml
+++ b/my-mule-app.yaml
@@ -18,7 +18,7 @@ spec:
       cpu: 1000m
       memory: 700Mi
     limits:
-      cpu: 4900m
+      cpu: 7500m
       memory: 2700Mi
   replicas: 1
   application:


### PR DESCRIPTION
This pull request increases the maximum CPU limit for the Mule application in my-mule-app.yaml from 4900m to 7500m. This change may be required to support higher workloads or performance requirements.

Please review and merge if appropriate.