### PR TITLE
Enable high availability for Mule app: clustered=true, replicas=2

### DIFF
--- a/my-mule-app.yaml
+++ b/my-mule-app.yaml
@@ -8,7 +8,7 @@ spec:
   target: jeff-rtf
   businessGroup: mulesoft
   environment: Sandbox2
-  clustered: false
+  clustered: true
   runtimeVersion: 4.6.16:2-java8
   resources:
     requests:
@@ -17,7 +17,7 @@ spec:
     limits:
       cpu: 5000m
       memory: 2700Mi
-  replicas: 1
+  replicas: 2
   application:
     ref:
       groupId: 1fbd2e46-128a-478c-a5fb-c03a655f82cd


### PR DESCRIPTION
This PR updates the Mule application deployment descriptor (`my-mule-app.yaml`) to enable high availability by setting `clustered: true` and `replicas: 2`. This ensures the app is ready for production with improved resilience and uptime.